### PR TITLE
Fix billing not showing registered members

### DIFF
--- a/src/Helpers/BillingHelper.php
+++ b/src/Helpers/BillingHelper.php
@@ -62,7 +62,7 @@ trait BillingHelper
 
     private function getTrackingMembers($corporation_id)
     {
-        return $this->getCorporationMemberTracking($corporation_id);
+        return $this->getCorporationMemberTracking($corporation_id)->get();
     }
 
     public function getMainsBilling($corporation_id, $year = null, $month = null)


### PR DESCRIPTION
With todays updates of seat. The service module from Corporation Members got changed.

https://github.com/eveseat/services/commit/697b5a3c32b0ae7e514540cd08b4b509862fa28c#diff-32d1b206f81f58d7f26bf6c50cb6431f

Which leads to not being able to display current amount of members registered.