### PR TITLE
perf(stats): reduce rendering time of numbers by 75%

### DIFF
--- a/src/Helpers/BillingHelper.php
+++ b/src/Helpers/BillingHelper.php
@@ -150,12 +150,12 @@ trait BillingHelper
             ->get();
     }
 
-    private function getCorporationBillByMonth($corporation_id, $year, $month)
+    private function getCorporationBillByMonth($year, $month)
     {
-        return CorporationBill::where("corporation_id", $corporation_id)
+        return CorporationBill::with('corporation')
             ->where("month", $month)
             ->where("year", $year)
-            ->first();
+            ->get();
     }
 
     private function getPastMainsBillingByMonth($corporation_id, $year, $month)

--- a/src/Helpers/BillingHelper.php
+++ b/src/Helpers/BillingHelper.php
@@ -146,7 +146,8 @@ trait BillingHelper
 
         return CorporationBill::select(DB::raw('DISTINCT month, year'))
             ->wherein('corporation_id', $corporation_ids)
-            ->orderBy('month', 'year', 'desc')
+            ->orderBy('year', 'desc')
+            ->orderBy('month', 'desc')
             ->get();
     }
 

--- a/src/Http/Controllers/BillingController.php
+++ b/src/Http/Controllers/BillingController.php
@@ -130,38 +130,12 @@ class BillingController extends Controller
 
     public function previousBillingCycle($year, $month)
     {
-        $summary = [];
-
         $corporations = $this->getCorporations();
 
-        foreach ($corporations as $corporation) {
-
-            $bill = $this->getCorporationBillByMonth($corporation->corporation_id, $year, $month);
-
-            if (is_null($bill))
-                continue;
-
-            $summary[$corporation->corporation_id]['id'] = $corporation->corporation_id;
-            $summary[$corporation->corporation_id]['name'] = $corporation->name;
-            $summary[$corporation->corporation_id]['pve_bill'] = $bill->pve_bill;
-            $summary[$corporation->corporation_id]['mining_bill'] = $bill->mining_bill;
-            $summary[$corporation->corporation_id]['pve_taxrate'] = $bill->pve_taxrate;
-            $summary[$corporation->corporation_id]['mining_taxrate'] = $bill->mining_taxrate;
-            $summary[$corporation->corporation_id]['mining_modifier'] = $bill->mining_modifier;
-            $summary[$corporation->corporation_id]['pve_paid'] = true;
-            $summary[$corporation->corporation_id]['mining_paid'] = true;
-
-            if (count($this->getPaidBillFromJournal($corporation->corporation_id, ($bill->pve_bill * ($bill->pve_taxrate / 100)), $month, $year)) === 0) {
-                $summary[$corporation->corporation_id]['pve_paid'] = false;
-            }
-
-            if (count($this->getPaidBillFromJournal($corporation->corporation_id, ($bill->mining_bill * ($bill->mining_modifier / 100) * ($bill->mining_taxrate / 100)), $month, $year)) === 0) {
-                $summary[$corporation->corporation_id]['mining_paid'] = false;
-            }
-        }
+        $stats = $this->getCorporationBillByMonth($year, $month)->sortBy('corporation.name');
 
         $dates = $this->getCorporationBillingMonths($corporations->pluck('corporation_id')->toArray());
 
-        return view('billing::pastbill', compact('summary', 'dates', 'year', 'month'));
+        return view('billing::pastbill', compact('stats', 'dates', 'year', 'month'));
     }
 }

--- a/src/Http/Controllers/BillingController.php
+++ b/src/Http/Controllers/BillingController.php
@@ -2,6 +2,7 @@
 
 namespace Denngarr\Seat\Billing\Http\Controllers;
 
+use Illuminate\Support\Facades\DB;
 use Seat\Web\Http\Controllers\Controller;
 use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Character\CharacterInfo;
@@ -16,74 +17,65 @@ class BillingController extends Controller
 {
     use MiningLedger, Ledger, CharacterLedger, BillingHelper;
 
-    public function getLiveBillingView($alliance_id = null)
+    public function getLiveBillingView(int $alliance_id = 0)
     {
-        $alliances = [];
-        $summary = [];
+        $start_date = carbon()->startOfMonth()->toDateString();
+        $end_date = carbon()->endOfMonth()->toDateString();
 
-        $corporations = $this->getCorporations();
+        $mining_stats = DB::table('corporation_member_trackings')
+            ->select('corporation_id')
+            ->leftJoin('character_minings', 'corporation_member_trackings.character_id', '=', 'character_minings.character_id')
+            ->whereBetween('date', [$start_date, $end_date])
+            ->groupBy('corporation_id');
 
-        foreach ($corporations as $corporation) {
-            $alliance = Alliance::find($corporation->alliance_id);
-
-            if ($alliance != null) {
-                $alliances[$alliance->alliance_id]['name'] = $alliance->name;
-            }
+        if (setting("pricevalue", true) == "m") {
+            $mining_stats = $mining_stats->selectRaw('SUM((character_minings.quantity / 100) * (invTypeMaterials.quantity * (? / 100)) * adjusted_price) as mining', [(float) setting("refinerate", true)])
+                ->leftJoin('invTypeMaterials', 'character_minings.type_id', '=', 'invTypeMaterials.typeID')
+                ->leftJoin('market_prices', 'invTypeMaterials.materialTypeID', '=', 'market_prices.type_id');
+        } else {
+            $mining_stats = $mining_stats->selectRaw('SUM(character_minings.quantity * market_prices.average_price) as mining')
+                ->leftJoin('market_prices', 'character_minings.type_id', '=', 'market_prices.type_id');
         }
 
-        foreach ($corporations as $corporation) {
+        $bounty_stats = DB::table('corporation_wallet_journals')
+            ->select('corporation_infos.corporation_id')
+            ->selectRaw('SUM(amount) / tax_rate as bounties')
+            ->join('corporation_infos', 'corporation_wallet_journals.corporation_id', '=', 'corporation_infos.corporation_id')
+            ->whereIn('ref_type', ['bounty_prizes', 'bounty_prize'])
+            ->whereBetween('date', [$start_date, $end_date])
+            ->groupBy('corporation_id');
 
-            if (($alliance_id) && ($corporation->alliance_id != $alliance_id))
-              continue;
+        $stats = DB::table('corporation_infos')
+            ->select('corporation_infos.corporation_id', 'corporation_infos.alliance_id', 'corporation_infos.name', 'corporation_infos.tax_rate', 'mining', 'bounties')
+            ->selectRaw('COUNT(corporation_member_trackings.character_id) as members')
+            ->selectRaw('COUNT(refresh_tokens.character_id) as actives')
+            ->join('corporation_member_trackings', 'corporation_infos.corporation_id', '=', 'corporation_member_trackings.corporation_id')
+            ->leftJoin('users', 'corporation_member_trackings.character_id', '=', 'users.id')
+            ->leftJoin('refresh_tokens', function ($join) {
+                $join->on('users.id', '=', 'refresh_tokens.character_id')
+                    ->whereNull('deleted_at');
+            })
+            ->leftJoin(DB::raw('(' . $mining_stats->toSql() . ') mining_stats'), function($join) {
+                $join->on('corporation_infos.corporation_id', '=', 'mining_stats.corporation_id');
+            })
+            ->leftJoin(DB::raw('(' . $bounty_stats->toSql() . ') bounty_stats'), function ($join) {
+                $join->on('corporation_infos.corporation_id', '=', 'bounty_stats.corporation_id');
+            })
+            ->mergeBindings($mining_stats)
+            ->mergeBindings($bounty_stats)
+            ->groupBy('corporation_id', 'alliance_id', 'name', 'tax_rate', 'mining', 'bounties')
+            ->orderBy('name');
 
-            $summary[$corporation->name]['id'] = $corporation->corporation_id;
-            $summary[$corporation->name]['alliance_id'] = $corporation->alliance_id;
+        if ($alliance_id !== 0)
+            $stats->where('alliance_id', $alliance_id);
 
-            $summary[$corporation->name]['mining'] = $this->getMiningTotal($corporation->corporation_id, date('Y'), date('n'));
-            $summary[$corporation->name]['tracking'] = 0;
+        $stats = $stats->get();
 
-            $tracking = $this->getTrackingMembers($corporation->corporation_id);
-            $summary[$corporation->name]['characters'] = $tracking->count();
+        $alliances = Alliance::whereIn('alliance_id', CorporationInfo::select('alliance_id'))->orderBy('name')->get();
 
-            $summary[$corporation->name]['tracking'] = $tracking->get()->filter(function ($value) {
-                if (is_null($value->user))
-                    return false;
+        $dates = $this->getCorporationBillingMonths($stats->pluck('corporation_id')->toArray());
 
-                return ! is_null($value->user->refresh_token);
-            })->count();
-
-            foreach ($tracking as $member) {
-                if ($member->key_ok) {
-                    $summary[$corporation->name]['tracking']++;
-                }
-            }
-
-            $summary[$corporation->name]['corptaxrate'] = .10;
-
-            if ($corporation->tax_rate) {
-                $summary[$corporation->name]['corptaxrate'] = $corporation->tax_rate;
-            }
-
-            $summary[$corporation->name]['bounty'] = $this->getBountyTotal($corporation->corporation_id, date('Y'), date('n')) / $summary[$corporation->name]['corptaxrate'];
-
-            if ($summary[$corporation->name]['characters'] == 0) {
-                $summary[$corporation->name]['characters'] = 1;
-            }
-
-            $summary[$corporation->name]['oretaxrate'] = setting('ioretaxrate', true);
-            $summary[$corporation->name]['oremodifier'] = setting('ioremodifier', true);
-            $summary[$corporation->name]['bountytaxrate'] = setting('ibountytaxrate', true);
-
-            if (($summary[$corporation->name]['tracking'] / $summary[$corporation->name]['characters']) < (setting('irate', true) / 100)) {
-                $summary[$corporation->name]['oretaxrate'] = setting('oretaxrate', true);
-                $summary[$corporation->name]['oremodifier'] = setting('oremodifier', true);
-                $summary[$corporation->name]['bountytaxrate'] = setting('bountytaxrate', true);
-            }
-        }
-
-        $dates = $this->getCorporationBillingMonths($corporations->pluck('corporation_id')->toArray());
-
-        return view('billing::summary', compact('alliances', 'summary', 'dates'));
+        return view('billing::summary', compact('alliances', 'stats', 'dates'));
     }
 
     private function getCorporations()

--- a/src/Models/CorporationBill.php
+++ b/src/Models/CorporationBill.php
@@ -3,12 +3,99 @@
 namespace Denngarr\Seat\Billing\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Models\Wallet\CorporationWalletJournal;
 
 class CorporationBill extends Model
 {
+    /**
+     * @var bool
+     */
     public $timestamps = true;
 
+    /**
+     * @var string
+     */
     protected $table = 'seat_billing_corp_bill';
 
-    protected $fillable = ['id', 'corporation_id', 'month', 'year', 'pve_bill', 'mining_bill', 'pve_taxrate', 'mining_taxrate', 'mining_modifier'];
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id', 'corporation_id', 'month', 'year', 'pve_bill', 'mining_bill',
+        'pve_taxrate', 'mining_taxrate', 'mining_modifier'];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function corporation()
+    {
+        return $this->belongsTo(CorporationInfo::class, 'corporation_id', 'corporation_id')
+            ->withDefault(function () {
+                return new CorporationInfo([
+                    'name' => 'Unknown',
+                ]);
+            });
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPaid(): bool
+    {
+        $pve_amount = $this->pve_bill * ($this->pve_taxrate / 100);
+        $mined_amount = $this->mining_bill * ($this->mining_modifier / 100) * ($this->mining_taxrate / 100);
+        $searched_amount = $pve_amount + $mined_amount;
+        $start_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->startOfMonth();
+        $end_date = $start_date->endOfMonth();
+
+        $journal_id = $this->getPaidBillFromJournal($searched_amount, $start_date->toDateString(), $end_date->toDateString())
+                           ->get();
+
+        return ! $journal_id->isEmpty();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPvePaid(): bool
+    {
+        $searched_amount = $this->pve_bill * ($this->pve_taxrate / 100);
+        $start_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->startOfMonth();
+        $end_date = $start_date->endOfMonth();
+
+        $journal_id = $this->getPaidBillFromJournal($searched_amount, $start_date->toDateString(), $end_date->toDateString())
+                           ->get();
+
+        return ! $journal_id->isEmpty();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMiningPaid(): bool
+    {
+        $searched_amount = $this->mining_bill * ($this->mining_modifier / 100) * ($this->mining_taxrate / 100);
+        $start_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->startOfMonth();
+        $end_date = $start_date->endOfMonth();
+
+        $journal_id = $this->getPaidBillFromJournal($searched_amount, $start_date->toDateString(), $end_date->toDateString())
+                           ->get();
+
+        return ! $journal_id->isEmpty();
+    }
+
+    /**
+     * @param float $searched_amount
+     * @param string $start_date
+     * @param string $end_date
+     * @return mixed
+     */
+    private function getPaidBillFromJournal(float $searched_amount, string $start_date, string $end_date)
+    {
+        return CorporationWalletJournal::where('amount', round($searched_amount, 2))
+            ->where('corporation_id', $this->corporation_id)
+            ->whereIn('ref_type', ['player_donation', 'contract_price_payment_corp'])
+            ->whereBetween('date', [$start_date, $end_date]);
+    }
 }

--- a/src/Models/CorporationBill.php
+++ b/src/Models/CorporationBill.php
@@ -47,9 +47,9 @@ class CorporationBill extends Model
         $mined_amount = $this->mining_bill * ($this->mining_modifier / 100) * ($this->mining_taxrate / 100);
         $searched_amount = $pve_amount + $mined_amount;
         $start_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->startOfMonth();
-        $end_date = $start_date->endOfMonth();
+        $end_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->endOfMonth();
 
-        $journal_id = $this->getPaidBillFromJournal($searched_amount, $start_date->toDateString(), $end_date->toDateString())
+        $journal_id = $this->getPaidBillFromJournal(round($searched_amount, 0), $start_date->toDateString(), $end_date->toDateString())
                            ->get();
 
         return ! $journal_id->isEmpty();
@@ -62,9 +62,9 @@ class CorporationBill extends Model
     {
         $searched_amount = $this->pve_bill * ($this->pve_taxrate / 100);
         $start_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->startOfMonth();
-        $end_date = $start_date->endOfMonth();
+        $end_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->endOfMonth();
 
-        $journal_id = $this->getPaidBillFromJournal($searched_amount, $start_date->toDateString(), $end_date->toDateString())
+        $journal_id = $this->getPaidBillFromJournal(round($searched_amount, 0), $start_date->toDateString(), $end_date->toDateString())
                            ->get();
 
         return ! $journal_id->isEmpty();
@@ -77,9 +77,9 @@ class CorporationBill extends Model
     {
         $searched_amount = $this->mining_bill * ($this->mining_modifier / 100) * ($this->mining_taxrate / 100);
         $start_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->startOfMonth();
-        $end_date = $start_date->endOfMonth();
+        $end_date = carbon(sprintf('%d-%d-01', $this->year, $this->month))->addMonth()->endOfMonth();
 
-        $journal_id = $this->getPaidBillFromJournal($searched_amount, $start_date->toDateString(), $end_date->toDateString())
+        $journal_id = $this->getPaidBillFromJournal(round($searched_amount, 0), $start_date->toDateString(), $end_date->toDateString())
                            ->get();
 
         return ! $journal_id->isEmpty();
@@ -91,11 +91,16 @@ class CorporationBill extends Model
      * @param string $end_date
      * @return mixed
      */
-    private function getPaidBillFromJournal(float $searched_amount, string $start_date, string $end_date)
+    private function getPaidBillFromJournal(int $searched_amount, string $start_date, string $end_date)
     {
-        return CorporationWalletJournal::where('amount', round($searched_amount, 2))
-            ->where('corporation_id', $this->corporation_id)
+        $min_amount = ($searched_amount + 1) * -1;
+        $max_amount = ($searched_amount - 1) * -1;
+
+        $query = CorporationWalletJournal::where('corporation_id', $this->corporation_id)
             ->whereIn('ref_type', ['player_donation', 'contract_price_payment_corp'])
-            ->whereBetween('date', [$start_date, $end_date]);
+            ->whereBetween('date', [$start_date, $end_date])
+            ->whereBetween('amount', [$min_amount, $max_amount]);
+
+        return $query;
     }
 }

--- a/src/resources/views/pastbill.blade.php
+++ b/src/resources/views/pastbill.blade.php
@@ -48,19 +48,22 @@
             <th>Tax Owed</th>
             <th>Paid</th>
           </tr>
-          @foreach($summary as $corp => $val)
+          @foreach($stats as $row)
             <tr>
-              <td>{{ $val["name"] }}</td>
-              <td>{{ number_format($val["mining_bill"], 2) }}</td>
-              <td>{{ $val['mining_modifier'] }}%</td>
-              <td>{{ number_format(($val["mining_bill"] * ($val["mining_modifier"] / 100)),2) }}</td>
-              <td>{{ $val['mining_taxrate'] }}%</td>
-              <td>{{ number_format((($val["mining_bill"] * ($val["mining_modifier"] / 100)) * ($val['mining_taxrate'] / 100)),2) }}</td>
-              @if ($val["mining_paid"] == true)
-                <td><i class="fa fa-check-circle text-green"></i></td>
-              @else
-                <td><i class="fa fa-close text-red"></i></td>
-            @endif
+              <td>{{ $row->corporation->name }}</td>
+              <td>{{ number_format($row->mining_bill, 2) }}</td>
+              <td>{{ $row->mining_modifier }}%</td>
+              <td>{{ number_format(($row->mining_bill * ($row->mining_modifier / 100)),2) }}</td>
+              <td>{{ $row->mining_taxrate }}%</td>
+              <td>{{ number_format((($row->mining_bill * ($row->mining_modifier / 100)) * ($row->mining_taxrate / 100)),2) }}</td>
+              <td>
+                @if ($row->isMiningPaid() || $row->isPaid())
+                <i class="fa fa-check-circle text-green"></i>
+                @else
+                <i class="fa fa-close text-red"></i>
+                @endif
+              </td>
+            </tr>
           @endforeach
         </table>
       </div>
@@ -73,18 +76,17 @@
             <th>Tax Owed</th>
             <th>Paid</th>
           </tr>
-          @foreach($summary as $corp => $val)
+          @foreach($stats as $row)
             <tr>
-              <td>{{ $val["name"] }}</td>
-              <td>{{ number_format($val["pve_bill"], 2) }}</td>
-              <td>{{ $val['pve_taxrate'] }}%</td>
-              <td>{{ number_format(($val["pve_bill"] * ($val['pve_taxrate'] / 100)),2) }}</td>
-              @if ($val["pve_paid"] == true)
+              <td>{{ $row->corporation->name }}</td>
+              <td>{{ number_format($row->pve_bill, 2) }}</td>
+              <td>{{ $row->pve_taxrate }}%</td>
+              <td>{{ number_format(($row->pve_bill * ($row->pve_taxrate / 100)),2) }}</td>
+              @if ($row->isPvePaid() || $row->isPaid())
                 <td><i class="fa fa-check-circle text-green"></i></td>
               @else
                 <td><i class="fa fa-close text-red"></i></td>
               @endif
-
             </tr>
           @endforeach
         </table>
@@ -93,8 +95,8 @@
         <div class="col-md-6">
           <select class="select" style="width: 50%" id="corpspinner">
             <option disabled selected value="0">Please Choose a Corp</option>
-            @foreach($summary as $corp => $val)
-              <option value="{{ $corp }}">{{ $val['name'] }}</option>
+            @foreach($stats as $row)
+              <option value="{{ $row->corporation->corporation_id }}">{{ $row->corporation->name }}</option>
             @endforeach
           </select>
         </div>

--- a/src/resources/views/pastbill.blade.php
+++ b/src/resources/views/pastbill.blade.php
@@ -57,10 +57,12 @@
               <td>{{ $row->mining_taxrate }}%</td>
               <td>{{ number_format((($row->mining_bill * ($row->mining_modifier / 100)) * ($row->mining_taxrate / 100)),2) }}</td>
               <td>
-                @if ($row->isMiningPaid() || $row->isPaid())
-                <i class="fa fa-check-circle text-green"></i>
-                @else
-                <i class="fa fa-close text-red"></i>
+                @if($row->mining_bill > 0)
+                  @if($row->isMiningPaid() || $row->isPaid())
+                  <i class="fa fa-check-circle text-green"></i>
+                  @else
+                  <i class="fa fa-close text-red"></i>
+                  @endif
                 @endif
               </td>
             </tr>
@@ -82,11 +84,15 @@
               <td>{{ number_format($row->pve_bill, 2) }}</td>
               <td>{{ $row->pve_taxrate }}%</td>
               <td>{{ number_format(($row->pve_bill * ($row->pve_taxrate / 100)),2) }}</td>
-              @if ($row->isPvePaid() || $row->isPaid())
-                <td><i class="fa fa-check-circle text-green"></i></td>
-              @else
-                <td><i class="fa fa-close text-red"></i></td>
-              @endif
+              <td>
+                @if($row->pve_bill > 0)
+                  @if ($row->isPvePaid() || $row->isPaid())
+                    <i class="fa fa-check-circle text-green"></i>
+                  @else
+                    <i class="fa fa-close text-red"></i>
+                  @endif
+                @endif
+              </td>
             </tr>
           @endforeach
         </table>

--- a/src/resources/views/summary.blade.php
+++ b/src/resources/views/summary.blade.php
@@ -39,8 +39,8 @@
           <select class="form-control" style="width: 25%" id="alliancespinner">
             <option selected disabled>Choose an Alliance</option>
             <option value="0">All Alliances</option>
-            @foreach($alliances as $alliance => $val)
-              <option value="{{ $alliance }}">{{ $val["name"] }}</option>
+            @foreach($alliances as $alliance)
+              <option value="{{ $alliance->alliance_id }}">{{ $alliance->name }}</option>
             @endforeach
           </select>
         </div>
@@ -57,20 +57,37 @@
           </tr>
           </thead>
           <tbody>
-          @foreach($summary as $corp => $val)
+          @foreach($stats as $row)
             <tr>
-              <td>{{ $corp }}</td>
-              <td style="text-align: right">{{ number_format($val["mining"], 2) }} ISK</td>
-              <td style="text-align: right">{{ $val['oremodifier'] }}%</td>
-              <td style="text-align: right">{{ number_format(($val["mining"] * ($val['oremodifier'] / 100)),2) }} ISK</td>
-              <td style="text-align: right">{{ $val['oretaxrate'] }}%</td>
-              <td style="text-align: right">{{ number_format((($val["mining"] * ($val['oremodifier'] / 100)) * ($val['oretaxrate'] / 100)),2) }} ISK</td>
-              @if ($val["characters"] > 0)
-                <td style="text-align: right">{{ $val["tracking"] }} / {{ $val["characters"] }}
-                  ({{ round(($val["tracking"] / $val["characters"]) * 100)  }}%)
-                </td>
+              <td>{{ $row->name }}</td>
+              <td class="text-right" data-order="{{ $row->mining }}">{{ number_format($row->mining, 2) }} ISK</td>
+              @if($row->actives / $row->members < (setting('irate', true) / 100))
+              <td class="text-right" data-order="{{ setting('oremodifier', true) }}">{{ setting('oremodifier', true) }}%</td>
               @else
-                <td style="text-align: right">0 / 0 (0%)</td>
+              <td class="text-right" data-order="{{ setting('ioremodifier', true) }}">{{ setting('ioremodifier', true) }}%</td>
+              @endif
+              @if($row->actives / $row->members < (setting('irate', true) / 100))
+              <td class="text-right" data-order="{{ $row->mining * (setting('oremodifier', true) / 100) }}">{{ number_format(($row->mining * (setting('oremodifier', true) / 100)), 2) }} ISK</td>
+              @else
+              <td class="text-right" data-order="{{ $row->mining * (setting('ioremodifier', true) / 100) }}">{{ number_format(($row->mining * (setting('ioremodifier', true) / 100)), 2) }} ISK</td>
+              @endif
+              @if($row->actives / $row->members < (setting('irate', true) / 100))
+              <td class="text-right" data-order="{{ setting('oretaxrate', true) }}">{{ setting('oretaxrate', true) }}%</td>
+              @else
+              <td class="text-right" data-order="{{ setting('ioretaxrate', true) }}">{{ setting('ioretaxrate', true) }}%</td>
+              @endif
+              @if($row->actives / $row->members < (setting('irate', true) / 100))
+              <td class="text-right" data-order="{{ ($row->mining * (setting('oremodifier', true) / 100)) * (setting('oretaxrate', true) / 100) }}">{{ number_format(($row->mining * (setting('oremodifier', true) / 100)) * (setting('oretaxrate', true) / 100), 2) }} ISK</td>
+              @else
+              <td class="text-right" data-order="{{ ($row->mining * (setting('ioremodifier', true) / 100)) * (setting('ioretaxrate', true) / 100) }}">{{ number_format(($row->mining * (setting('ioremodifier', true) / 100)) * (setting('ioretaxrate', true) / 100), 2) }} ISK</td>
+              @endif
+              @if ($row->members > 0)
+              <td class="text-right" data-order="{{ $row->actives / $row->members }}">
+                {{ $row->actives }} / {{ $row->members }}
+                ({{ round(($row->actives / $row->members) * 100) }}%)
+              </td>
+              @else
+              <td class="text-right" data-order="0">0 / 0 (0%)</td>
               @endif
             </tr>
           @endforeach
@@ -89,18 +106,27 @@
           </tr>
           </thead>
           <tbody>
-          @foreach($summary as $corp => $val)
+          @foreach($stats as $row)
             <tr>
-              <td>{{ $corp }}</td>
-              <td style="text-align: right">{{ number_format($val["bounty"], 2) }} ISK</td>
-              <td style="text-align: right">{{ $val['bountytaxrate'] }}%</td>
-              <td style="text-align: right">{{ number_format(($val["bounty"] * ($val['bountytaxrate'] / 100)),2) }} ISK</td>
-              @if ($val["characters"] > 0)
-                <td style="text-align: right">{{ $val["tracking"] }} / {{ $val["characters"] }}
-                  ({{ round(($val["tracking"] / $val["characters"]) * 100)  }}%)
-                </td>
+              <td>{{ $row->name }}</td>
+              <td class="text-right" data-order="{{ $row->bounties }}">{{ number_format($row->bounties, 2) }} ISK</td>
+              @if($row->actives / $row->members < (setting('irate', true) / 100))
+              <td class="text-right" data-order="{{ setting('bountytaxrate', true) }}">{{ setting('bountytaxrate', true) }}%</td>
               @else
-                <td style="text-align: right">0 / 0 (0%)</td>
+              <td class="text-right" data-order="{{ setting('ibountytaxrate', true) }}">{{ setting('ibountytaxrate', true) }}%</td>
+              @endif
+              @if($row->actives / $row->members < (setting('irate', true) / 100))
+              <td class="text-right" data-order="{{ $row->bounties * (setting('bountytaxrate', true)) }}">{{ number_format(($row->bounties * (setting('bountytaxrate', true) / 100)),2) }} ISK</td>
+              @else
+              <td class="text-right" data-order="{{ $row->bounties * (setting('ibountytaxrate', true)) }}">{{ number_format(($row->bounties * (setting('ibountytaxrate', true) / 100)),2) }} ISK</td>
+              @endif
+              @if ($row->members > 0)
+              <td class="text-right" data-order="{{ $row->actives / $row->members }}">
+                {{ $row->actives }} / {{ $row->members }}
+                ({{ round(($row->actives / $row->members) * 100)  }}%)
+              </td>
+              @else
+              <td class="text-right" data-order="0">0 / 0 (0%)</td>
               @endif
             </tr>
           @endforeach
@@ -111,8 +137,8 @@
         <div class="col-md-6">
           <select class="form-control" style="width: 50%" id="corpspinner">
             <option disabled selected value="0">Please Choose a Corp</option>
-            @foreach($summary as $corp => $val)
-              <option value="{{ $val['id'] }}">{{ $corp }}</option>
+            @foreach($stats as $row)
+              <option value="{{ $row->corporation_id }}">{{ $row->name }}</option>
             @endforeach
           </select>
         </div>


### PR DESCRIPTION
replace Eloquent manual processing by raw query which is directly pulling
 - corporation basics information (id, alliance, name)
 - members (using corporation tracking)
 - active tokens (by counting registered token not deleted)
 - computed bounties together with mining value.